### PR TITLE
fix: require Node.js 22+ for Astro 6 compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Personal site and blog built with [Astro](https://astro.build), deployed to GitH
 
 | Layer | Technology |
 |-------|-----------|
-| Framework | [Astro 4](https://astro.build) |
-| Styling | [Tailwind CSS 3](https://tailwindcss.com) |
+| Framework | [Astro 6](https://astro.build) |
+| Styling | [Tailwind CSS 4](https://tailwindcss.com) |
 | Content | MDX via `@astrojs/mdx` |
 | Syntax highlighting | Shiki (bundled with Astro) |
 | Hosting | GitHub Pages |
@@ -15,7 +15,7 @@ Personal site and blog built with [Astro](https://astro.build), deployed to GitH
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - npm
 
 ## Local development


### PR DESCRIPTION
Astro 6 requires Node.js >= 22.12.0. Update the GitHub Actions workflow and README to use Node 22 instead of 20.

Also update README stack table to reflect Astro 6 and Tailwind v4.

https://claude.ai/code/session_01MvyJ5HiXAPHBTT8PvbcAAe